### PR TITLE
feat: Cascade prices and block transaction-referenced asset deletes

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -22,6 +22,7 @@ export async function initDb(path: string): Promise<Database> {
       });
       db.exec(
         `
+          PRAGMA foreign_keys = ON;
           CREATE TABLE IF NOT EXISTS assets (
             symbol TEXT PRIMARY KEY,
             name TEXT NOT NULL,
@@ -34,8 +35,8 @@ export async function initDb(path: string): Promise<Database> {
             price REAL NOT NULL,
             asset_symbol TEXT NOT NULL,
             fiat_symbol TEXT NOT NULL,
-            FOREIGN KEY(asset_symbol) REFERENCES assets(symbol),
-            FOREIGN KEY(fiat_symbol) REFERENCES assets(symbol),
+            FOREIGN KEY(asset_symbol) REFERENCES assets(symbol) ON DELETE CASCADE,
+            FOREIGN KEY(fiat_symbol) REFERENCES assets(symbol) ON DELETE CASCADE,
             PRIMARY KEY (unix_timestamp, asset_symbol, fiat_symbol)
           );
           CREATE TABLE IF NOT EXISTS transactions (
@@ -195,18 +196,13 @@ export async function updateAsset(symbol: string, name: string, asset_type: Asse
 export async function deleteAsset(symbol: string): Promise<Asset[]> {
   return new Promise<any[]>((resolve, reject) => {
     if (!db) return reject(new Error('DB not initialized'));
-    db.serialize(() => {
-      if (!db) return reject(new Error('DB not initialized'));
-      db.all('DELETE FROM prices WHERE asset_symbol = ? RETURNING *', [symbol], (err, rows) => {
-        if (err) return reject(err);
-        console.log(`Deleted ${rows.length} price entries for asset: ${symbol}`);
-      });
-      db.all('DELETE FROM assets WHERE symbol = ? RETURNING *', [symbol], (err, rows) => {
-        if (err) return reject(err);
-        if (!rows.length) return reject(new Error(`Failed to delete asset with symbol: ${symbol}`));
-        console.log(`Deleted asset: ${symbol}`);
-        resolve(rows);
-      });
+    // Associated prices are removed automatically via ON DELETE CASCADE.
+    // If any transaction references this asset, the DB raises a FK violation.
+    db.all('DELETE FROM assets WHERE symbol = ? RETURNING *', [symbol], (err, rows) => {
+      if (err) return reject(err);
+      if (!rows.length) return reject(new Error(`Failed to delete asset with symbol: ${symbol}`));
+      console.log(`Deleted asset: ${symbol}`);
+      resolve(rows);
     });
   });
 }
@@ -214,17 +210,11 @@ export async function deleteAsset(symbol: string): Promise<Asset[]> {
 export async function deleteAllAssets(): Promise<Asset[]> {
   return new Promise<any[]>((resolve, reject) => {
     if (!db) return reject(new Error('DB not initialized'));
-    db.serialize(() => {
-      if (!db) return reject(new Error('DB not initialized'));
-      db.all('DELETE FROM prices RETURNING *', (err, rows) => {
-        if (err) return reject(err);
-        console.log(`Deleted ${rows.length} price entries`);
-      });
-      db.all('DELETE FROM assets RETURNING *', (err, rows) => {
-        if (err) return reject(err);
-        console.log(`Deleted ${rows.length} assets`);
-        resolve(rows);
-      });
+    // Associated prices are removed automatically via ON DELETE CASCADE.
+    db.all('DELETE FROM assets RETURNING *', (err, rows) => {
+      if (err) return reject(err);
+      console.log(`Deleted ${rows.length} assets`);
+      resolve(rows);
     });
   });
 }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -178,4 +178,30 @@ describe('DB functions', () => {
     if (assets instanceof Error) throw assets;
     expect(assets.some((a: Asset) => a.symbol === symbol)).toBeFalsy();
   });
+
+  it('should cascade delete prices when the referenced asset is deleted', async () => {
+    const assets = await getAssets();
+    const fiat = assets.find((a: Asset) => a.asset_type === AssetType.FIAT)?.symbol;
+    if (!fiat) throw new Error('No fiat asset found');
+    // Add a throwaway asset with an associated price
+    await addAsset({ name: 'Cascade', symbol: 'CAS', asset_type: AssetType.BLOCKCHAIN, launch_date: 1672531199000, logo_url: 'https://example.com/cas-logo.png' });
+    const date = new Date('2024-08-01');
+    await addPrice({ unix_timestamp: date.getTime(), price: 42, asset_symbol: 'CAS', fiat_symbol: fiat });
+    const beforePrices = await getPrices({ asset_symbol: 'CAS' });
+    expect(beforePrices.some((p: Price) => p.asset_symbol === 'CAS')).toBeTruthy();
+    await deleteAsset('CAS');
+    const afterPrices = await getPrices({ asset_symbol: 'CAS' });
+    expect(afterPrices.some((p: Price) => p.asset_symbol === 'CAS')).toBeFalsy();
+  });
+
+  it('should block asset deletion when the asset is referenced by a transaction', async () => {
+    const assets = await getAssets();
+    const btc = assets.find((a: Asset) => a.symbol === 'BTC');
+    if (!btc) throw new Error('BTC asset expected to exist from earlier tests');
+    // Earlier tests inserted a transaction that references BTC as send_asset_symbol.
+    await expect(deleteAsset('BTC')).rejects.toThrow();
+    // And the asset should still exist.
+    const after = await getAssets();
+    expect(after.some((a: Asset) => a.symbol === 'BTC')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Enable PRAGMA foreign_keys so the FK constraints declared on prices and transactions are actually enforced, and declare ON DELETE CASCADE on the two price FK columns so prices follow their asset.

Behaviour changes:
- Deleting an asset automatically removes its price history (CASCADE)
- Deleting an asset referenced by any transaction now fails with a FK violation instead of silently leaving an orphan row
- deleteAsset and deleteAllAssets stop manually cascading prices (the DB handles it now)

Tests: 2 new db tests covering price cascade and the blocked-delete case when an asset is referenced by a transaction.