### PR TITLE
feat(transactions): Add note search filter and move CSV export button

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -488,6 +488,7 @@ export async function getTransactions(filters?: {
   date_from?: number;
   date_to?: number;
   wallet_name?: string;
+  note?: string;
   limit?: number;
   offset?: number;
 }): Promise<Paginated<Transaction>> {
@@ -536,6 +537,11 @@ export async function getTransactions(filters?: {
       if (filters.wallet_name) {
         sql += ' AND (t.from_wallet_name = ? OR t.to_wallet_name = ?)';
         params.push(filters.wallet_name, filters.wallet_name);
+      }
+      if (filters.note) {
+        // Case-insensitive substring match on the notes field.
+        sql += ' AND t.notes LIKE ?';
+        params.push(`%${filters.note}%`);
       }
     }
     sql += ' ORDER BY t.unix_timestamp ASC';

--- a/src/server.ts
+++ b/src/server.ts
@@ -494,20 +494,21 @@ app.post('/api/import-transactions', express.text({ type: 'text/csv', limit: '10
 
 // Retrieve
 app.get('/api/transactions', async (req, res) => {
-  const { asset, type, date_from, date_to, wallet_name, limit, offset } = req.query;
+  const { asset, type, date_from, date_to, wallet_name, note, limit, offset } = req.query;
   res.json(await getTransactions({
     asset: asset as string | undefined,
     type: type as string | undefined,
     date_from: date_from ? Number(date_from) : undefined,
     date_to: date_to ? Number(date_to) : undefined,
     wallet_name: wallet_name as string | undefined,
+    note: note as string | undefined,
     limit: limit !== undefined ? Number(limit) : undefined,
     offset: offset !== undefined ? Number(offset) : undefined
   }));
 });
 
 app.get('/api/download-transactions-csv', async (req, res) => {
-  const { asset, type, date_from, date_to, wallet_name } = req.query;
+  const { asset, type, date_from, date_to, wallet_name, note } = req.query;
   // Pull every matching row (no pagination) so the export reflects the full
   // filtered query, not just the page the user is currently looking at.
   const { items } = await getTransactions({
@@ -516,6 +517,7 @@ app.get('/api/download-transactions-csv', async (req, res) => {
     date_from: date_from ? Number(date_from) : undefined,
     date_to: date_to ? Number(date_to) : undefined,
     wallet_name: wallet_name as string | undefined,
+    note: note as string | undefined,
   });
 
   // Emit the same column set the import endpoint expects, so an export →

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -566,7 +566,7 @@
           <input type="file" id="import-transactions-file" accept=".csv">
         </label>
         <button id="import-transactions-btn">Upload</button>
-        <button id="download-example-csv-btn" type="button">Download Example CSV</button>
+        <a id="download-example-csv-btn" href="/transactions.csv" download="example-transactions.csv">Download Example CSV</a>
         <span id="import-transactions-status" style="margin-left:1em;color:#d9534f;"></span>
       </div>
     </div>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -364,6 +364,7 @@
   <div class="tab-content" id="transactions-content" style="display:none;">
     <h2>Transactions</h2>
     <button id="open-add-import-modal-btn" style="margin-bottom:1em;">Add/Import Transaction</button>
+    <button id="download-csv-btn" type="button" style="margin-bottom:1em;">Download CSV (Filtered)</button>
     <div id="transactions-filters" style="margin-bottom:1em;">
       <label>Asset:
         <select id="transactions-filter-asset">
@@ -382,6 +383,9 @@
           <option value="">All</option>
           <!-- Populated in index.js -->
         </select>
+      </label>
+      <label>Note:
+        <input type="text" id="transactions-filter-note" placeholder="Search notes">
       </label>
       <label>Date From:
         <input type="date" id="transactions-filter-date-from">
@@ -562,7 +566,6 @@
           <input type="file" id="import-transactions-file" accept=".csv">
         </label>
         <button id="import-transactions-btn">Upload</button>
-        <button id="download-csv-btn" type="button">Download CSV (Filtered)</button>
         <span id="import-transactions-status" style="margin-left:1em;color:#d9534f;"></span>
       </div>
     </div>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -566,6 +566,7 @@
           <input type="file" id="import-transactions-file" accept=".csv">
         </label>
         <button id="import-transactions-btn">Upload</button>
+        <button id="download-example-csv-btn" type="button">Download Example CSV</button>
         <span id="import-transactions-status" style="margin-left:1em;color:#d9534f;"></span>
       </div>
     </div>

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -636,12 +636,14 @@ function readTransactionFilterParams(): URLSearchParams {
   const assetSelect = document.getElementById('transactions-filter-asset') as HTMLSelectElement;
   const typeSelect = document.getElementById('transactions-filter-type') as HTMLSelectElement;
   const walletSelect = document.getElementById('transactions-filter-wallet') as HTMLSelectElement;
+  const noteInput = document.getElementById('transactions-filter-note') as HTMLInputElement;
   const dateFromInput = document.getElementById('transactions-filter-date-from') as HTMLInputElement;
   const dateToInput = document.getElementById('transactions-filter-date-to') as HTMLInputElement;
   const params = new URLSearchParams();
   if (assetSelect?.value) params.append('asset', assetSelect.value);
   if (typeSelect?.value) params.append('type', typeSelect.value);
   if (walletSelect?.value) params.append('wallet_name', walletSelect.value);
+  if (noteInput?.value.trim()) params.append('note', noteInput.value.trim());
   if (dateFromInput?.value) params.append('date_from', String(Date.parse(dateFromInput.value)));
   if (dateToInput?.value) {
     // End-of-day inclusive, matching the table filter behavior.
@@ -658,6 +660,7 @@ async function renderTransactions(): Promise<void> {
   const assetSelect = document.getElementById('transactions-filter-asset') as HTMLSelectElement;
   const typeSelect = document.getElementById('transactions-filter-type') as HTMLSelectElement;
   const walletSelect = document.getElementById('transactions-filter-wallet') as HTMLSelectElement;
+  const noteInput = document.getElementById('transactions-filter-note') as HTMLInputElement;
   const dateFromInput = document.getElementById('transactions-filter-date-from') as HTMLInputElement;
   const dateToInput = document.getElementById('transactions-filter-date-to') as HTMLInputElement;
   const filterBtn = document.getElementById('transactions-filter-btn') as HTMLButtonElement;
@@ -675,6 +678,7 @@ async function renderTransactions(): Promise<void> {
     assetSelect.value = '';
     typeSelect.value = '';
     walletSelect.value = '';
+    noteInput.value = '';
     dateFromInput.value = '';
     dateToInput.value = '';
     paginationState['transactions-table'].page = 1;

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -976,6 +976,17 @@ function showBulkEditModal() {
   window.location.href = '/api/download-transactions-csv' + (qs ? `?${qs}` : '');
 };
 
+// Download the bundled example CSV so users have a template showing the
+// expected import column format.
+(document.getElementById('download-example-csv-btn') as HTMLButtonElement).onclick = function() {
+  const a = document.createElement('a');
+  a.href = '/transactions.csv';
+  a.download = 'example-transactions.csv';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+};
+
 (document.getElementById('import-transactions-btn') as HTMLButtonElement).onclick = async function() {
   const fileInput = document.getElementById('import-transactions-file') as HTMLInputElement;
   const status = document.getElementById('import-transactions-status') as HTMLElement;

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -976,17 +976,6 @@ function showBulkEditModal() {
   window.location.href = '/api/download-transactions-csv' + (qs ? `?${qs}` : '');
 };
 
-// Download the bundled example CSV so users have a template showing the
-// expected import column format.
-(document.getElementById('download-example-csv-btn') as HTMLButtonElement).onclick = function() {
-  const a = document.createElement('a');
-  a.href = '/transactions.csv';
-  a.download = 'example-transactions.csv';
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-};
-
 (document.getElementById('import-transactions-btn') as HTMLButtonElement).onclick = async function() {
   const fileInput = document.getElementById('import-transactions-file') as HTMLInputElement;
   const status = document.getElementById('import-transactions-status') as HTMLElement;


### PR DESCRIPTION
Extend the transactions filters with a free-text Note search that does a case-insensitive substring match on the notes column. The new `note` query param is threaded through getTransactions and applied by both the table fetch (/api/transactions) and the CSV export (/api/download-transactions-csv) via the shared filter param builder, so the two stay in lockstep.

Also move the "Download CSV (Filtered)" button out of the Add/Import Transaction modal up to the Transactions tab toolbar, next to the Add/Import button, so exporting the current filtered view no longer requires opening the modal.